### PR TITLE
Workers: Improve logging for funding/staking of applications

### DIFF
--- a/packages/backend/src/workers/application.ts
+++ b/packages/backend/src/workers/application.ts
@@ -78,7 +78,6 @@ async function stakeApplication(
   app: IPreStakedApp,
   chain = "0002"
 ): Promise<void> {
-  console.log("Got app ", app);
   const { address, passPhrase, privateKey } = app.freeTierApplicationAccount;
   const { balance } = (await getBalance(address)) as QueryBalanceResponse;
 

--- a/packages/backend/src/workers/application.ts
+++ b/packages/backend/src/workers/application.ts
@@ -59,6 +59,12 @@ async function createApplicationAndFund(ctx): Promise<void> {
     freeTierAccount.addressHex
   );
 
+  if (!txHash) {
+    ctx.logger.warn(
+      `Funds were not sent for app ${newAppForPool.freeTierApplicationAccount.address}! This is an issue with connecting to the network with PocketJS.`
+    );
+  }
+
   newAppForPool.status = APPLICATION_STATUSES.AWAITING_STAKING;
   newAppForPool.fundingTxHash = txHash;
   await newAppForPool.save();
@@ -99,6 +105,9 @@ async function stakeApplication(
   app.status = APPLICATION_STATUSES.READY;
   app.stakingTxHash = txHash;
   app.chain = chain;
+  ctx.logger.log(
+    `App ${app.freeTierApplicationAccount.address} is now ready: tx hash ${txHash}`
+  );
   await app.save();
 
   ctx.logger.log(


### PR DESCRIPTION
Improves the logging of info from the application workers—mainly to include more info in critical paths (sending txs on pocketJS).