### PR TITLE
Workers: turn xdai app amount down

### DIFF
--- a/packages/backend/src/workers/config.ts
+++ b/packages/backend/src/workers/config.ts
@@ -68,7 +68,7 @@ const MAIN_CHAINS = {
   ETHEREUM_XDAI_FULL: {
     ticker: "POA",
     id: "0027",
-    limit: 10,
+    limit: 3,
   },
   POCKET_MAINNET: {
     ticker: "POKT",


### PR DESCRIPTION
The initial pool already contains enough xDAI apps to be claimed, so workers will be turned down.